### PR TITLE
[#S06P22A506-143] 🚀feat : save profileImage in server path!!

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -83,8 +83,17 @@
 		    <artifactId>junit-jupiter-api</artifactId>
 		    <scope>test</scope>
 		</dependency>
+		<dependency>
+		  <groupId>commons-fileupload</groupId>
+		  <artifactId>commons-fileupload</artifactId>
+		  <version>1.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/backend/src/main/java/com/blackbelt/BackendApplication.java
+++ b/backend/src/main/java/com/blackbelt/BackendApplication.java
@@ -3,9 +3,15 @@ package com.blackbelt;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
+import com.blackbelt.config.FileStorageProperties;
+
 @SpringBootApplication
+@EnableConfigurationProperties({
+	FileStorageProperties.class
+})
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/blackbelt/config/FileStorageProperties.java
+++ b/backend/src/main/java/com/blackbelt/config/FileStorageProperties.java
@@ -1,0 +1,16 @@
+package com.blackbelt.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "file")
+public class FileStorageProperties {
+    private String uploadDir;
+
+    public String getUploadDir() {
+        return uploadDir;
+    }
+
+    public void setUploadDir(String uploadDir) {
+        this.uploadDir = uploadDir;
+    }
+}

--- a/backend/src/main/java/com/blackbelt/exception/FileStorageException.java
+++ b/backend/src/main/java/com/blackbelt/exception/FileStorageException.java
@@ -1,0 +1,11 @@
+package com.blackbelt.exception;
+
+public class FileStorageException extends RuntimeException {
+    public FileStorageException(String message) {
+        super(message);
+    }
+
+    public FileStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/blackbelt/exception/MyFileNotFoundException.java
+++ b/backend/src/main/java/com/blackbelt/exception/MyFileNotFoundException.java
@@ -1,0 +1,15 @@
+package com.blackbelt.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FAILED_DEPENDENCY)
+public class MyFileNotFoundException extends RuntimeException {
+    public MyFileNotFoundException(String message) {
+        super(message);
+    }
+
+    public MyFileNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/blackbelt/service/FileStorageService.java
+++ b/backend/src/main/java/com/blackbelt/service/FileStorageService.java
@@ -1,0 +1,69 @@
+package com.blackbelt.service;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.blackbelt.config.FileStorageProperties;
+import com.blackbelt.exception.FileStorageException;
+import com.blackbelt.exception.MyFileNotFoundException;
+
+@Service
+public class FileStorageService {
+
+    private final Path fileStorageLocation;
+
+    @Autowired
+    public FileStorageService(FileStorageProperties fileStorageProperties) {
+        this.fileStorageLocation = Paths.get(fileStorageProperties.getUploadDir())
+                .toAbsolutePath().normalize();
+
+        try {
+            Files.createDirectories(this.fileStorageLocation);
+        } catch (Exception ex) {
+            throw new FileStorageException("경로 생성 불가", ex);
+        }
+    }
+
+    public String[] storeFile(MultipartFile file) {
+        // Normalize file name
+        String fileName = StringUtils.cleanPath(file.getOriginalFilename());
+        try {
+            if(fileName.contains("..")) {
+                throw new FileStorageException("파일 이름 오류" + fileName);
+            }
+
+            //저장 경로에 파일을 복사한다. 이미 있는 경우 덮어쓴다.
+            Path targetLocation = this.fileStorageLocation.resolve(fileName);
+            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+            return new String[] {fileName, targetLocation.toString()};
+        } catch (IOException ex) {
+            throw new FileStorageException("파일 생성 불가 " + fileName + ". Please try again!", ex);
+        }
+    }
+
+    public Resource loadFileAsResource(String fileName) {
+        try {
+            Path filePath = this.fileStorageLocation.resolve(fileName).normalize();
+            Resource resource = new UrlResource(filePath.toUri());
+            if(resource.exists()) {
+                return resource;
+            } else {
+                throw new MyFileNotFoundException("File not found " + fileName);
+            }
+        } catch (MalformedURLException ex) {
+            throw new MyFileNotFoundException("File not found " + fileName, ex);
+        }
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,15 +8,24 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://j6a506.p.ssafy.io:5050/taekwondo?serverTimezone=UTC&useUniCode=yes&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=FireFistYoon_ssooChoi_a506!
+#spring.datasource.url=jdbc:mysql://localhost:3306/taekwondo?serverTimezone=UTC&useUniCode=yes&characterEncoding=UTF-8
+#spring.datasource.username=root
+#spring.datasource.password=dnsmsla13535##
 
 spring.jpa.show-sql=true
 #MyBatis Setting
 mybatis.type-aliases-package=com.blackbelt.model
 mybatis.mapper-locations=mapper/*.xml
 
+
+# Enable multipart uploads
+spring.servlet.multipart.enabled=true
 #File Upload size Setting
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB
+
+#file upload dir
+file.upload-dir=/var/lib/jenkins/upload
 
 #log level Setting
 logging.level.root=info
@@ -25,3 +34,4 @@ logging.level.com.blackbelt=debug
 #jwttoken
 security.jwt.token.secret-key=tAekWondOmasteRcat
 security.jwt.token.expire-length=36000000
+


### PR DESCRIPTION
파일 업로드 개발과정

1. 폼 xml commons-fileupload dependency 추가

2. 어플리케이션 프로퍼티
	# Enable multipart uploads
	spring.servlet.multipart.enabled=true
	#File Upload size Setting
	spring.servlet.multipart.max-file-size=5MB
	spring.servlet.multipart.max-request-size=5MB
	#file upload dir
	file.upload-dir=/var/lib/jenkins/  >> 3번에 설명

3. 프로퍼티에서 인식시키기 위해 컴피그 클래스를 생성했다
	@ConfigurationProperties(prefix = "file")
	클래스에 위 어노테이션을 붙이고 POM.XML에 연계시키면
	file.upload-dir 이걸 인식한다

4. @SpringBootApplication 클래스에서 컨피그를 보내주도록
	@EnableConfigurationProperties({
		FileStorageProperties.class
	}) // 이내용을 추가했다.

5. 커스텀 예외처리를 했다. RuntimeException를 상속받아서 구현했다.


6. 컨트롤
	폼데이터를 받아서
	권한 확인 후 파일 이름과 경로에 맞게 파일을 복사해 저장하고
	저장정보(경로)를 디비에 저장한다.
	이과정 잘 진행되면 저장 경로를 반환한다.

7. 저장경로
	etc 서버에 var/lib/jenkins/upload에 저장이 되는데
	경로만 주면 프론트에서 쓸 수 있을지는 연구를 해봐야한다.
	"profileSavePath": "C:\\var\\lib\\jenkins\\upload\\캡처_2022_02_22_15_06_14_185.png",
	머 이런식으로 나오고 있는데 차후에 수정해서 보내주도록 한다.

8. 제한사항
	사이즈 5MB로 제한했다